### PR TITLE
Admins can generate Passwords for Applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^16.8.4",
     "react-chartjs-2": "^2.7.4",
     "react-component-queries": "^2.3.0",
+    "react-csv": "^1.1.2",
     "react-d3-map": "^0.8.3",
     "react-device-detect": "^1.9.10",
     "react-dom": "^16.11.0",

--- a/src/components/Layout/Sidebar.js
+++ b/src/components/Layout/Sidebar.js
@@ -6,7 +6,7 @@ import {
   MdAssignment,
   MdKeyboardArrowDown,
   MdSettings,
-  MdAccessTime,
+  MdReport,
   MdAssignmentInd,
   MdPerson,
   MdGroup,
@@ -39,7 +39,7 @@ const navItems = [
 ];
 
 const navAdminItems = [
-  { to: '/phasen', name: "Phasen", exact: true, Icon: MdAccessTime},
+  { to: '/phasen', name: "Einstellungen", exact: true, Icon: MdSettings},
   { to: '/application', name: "Anmeldungen", exact: false, Icon: MdAssignmentInd},
   { to: '/workshop-list', name: "Workshop-Liste", exact: false, Icon: MdGroup},
 ];
@@ -98,7 +98,7 @@ class Sidebar extends React.Component {
                   >
                     <BSNavLink className={bem.e('nav-item-collapse')}>
                       <div className="d-flex">
-                        <MdSettings className={bem.e('nav-item-icon')} />
+                        <MdReport className={bem.e('nav-item-icon')} />
                         <span className=" align-self-start">Ausrichter</span>
                       </div>
                       <MdKeyboardArrowDown

--- a/src/pages/administrator/PhasesPage.js
+++ b/src/pages/administrator/PhasesPage.js
@@ -16,9 +16,12 @@ import {
 } from 'reactstrap'
 import PageSpinner from '../../components/PageSpinner';
 import ConferenceActions from '../../redux/conferenceRedux';
+import { CSVLink } from "react-csv";
+import Delay from '../../components/Delay';
+import { FaDownload } from 'react-icons/fa';
 
 const phases = [
-    { name: 'Workschopvorschlag einreichen', id: 'workshopSuggestionPhase'},
+    { name: 'Workshopvorschlag einreichen', id: 'workshopSuggestionPhase'},
     { name: 'Anmeldung zur Konferenz', id:'conferenceApplicationPhase'},
     { name: 'Workshop-Anmeldung', id: 'workshopApplicationPhase'}
 ]
@@ -34,6 +37,10 @@ class DashboardPage extends React.Component {
             workshopSuggestionPhase: false,
             otherKeys: 50,
         }
+    }
+
+    componentDidMount() {
+        this.props.getPasswordList();
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -74,14 +81,48 @@ class DashboardPage extends React.Component {
         })
     }
 
+    getCouncilPasswords(passwordList){
+        var result = [["Passwort", "Priorität", "Fachschafts-ID", "Name", "Stadt", "Hochschule", "Bundesland", "Adresse", "E-Mail-Adresse", "Passwort-ID"]]
+        passwordList.forEach(row => {
+            if (row.council) {
+                result.push([
+                    row.password,
+                    row.priority,
+                    row.council.councilID,
+                    row.council.name,
+                    row.council.city,
+                    row.council.university,
+                    row.council.state,
+                    row.council.address,
+                    row.council.contactEmail,
+                    row.id,
+                ])
+            } 
+        })
+        return result
+    }
+
+    getOtherPasswords(passwordList){
+        var result = [["Passwort", "Passwort-ID"]]
+        passwordList.forEach(row => {
+            if (!row.council) {
+                result.push([
+                    row.password,
+                    row.id,
+                ])
+            } 
+        })
+        return result
+    }
+
   render() {
-    const { conference } = this.props
+    const { conference, passwordList } = this.props
     if (!conference) {
       return (
         <PageSpinner color="primary" />
       );
     }
-    
+
     return (
       <Page
         className="PhasesPage"
@@ -92,7 +133,7 @@ class DashboardPage extends React.Component {
                 <Card>
                     <CardHeader>
                         <Row style={{justifyContent: 'space-between', alignItems: 'center'}}>
-                            Phasen-Einstellungen
+                            Anmeldephasen
                             <div>
                             { !this.state.editing && <Button onClick={() => this.setState({ editing: true})}>Bearbeiten</Button>}
                             { this.state.editing && <Button onClick={() => this.onCancelPress()}>Abbrechen</Button>}
@@ -129,19 +170,61 @@ class DashboardPage extends React.Component {
                         </CardTitle>
                     </CardHeader>
                     <CardBody>
-                         <Alert color="info">Hier könnt ihr eure Anmeldecodes erstellen und herunterladen. Zu den Weiteren Codes zählen Alumni, Rat und mögliche Helfer-Anmeldungen.<br/><b>Da die Codes nur einmal erstellt werden können, gebt besser ein paar Codes mehr an als nötig.</b></Alert>
-                        <Row>
-                            <Col xs={12} md={2}>
-                                <Input 
-                                    type="number"
-                                    value={this.state.otherKeys}
-                                    onChange={(e) => this.setState({ otherKeys: e.currentTarget.value})}
-                                />
-                            </Col>
-                            <Col>
-                                <Button onClick={() => this.props.generateAuthenticationKeys(this.state.otherKeys)}>Erstellen</Button>
-                            </Col>
-                        </Row>
+                        <Delay >
+                            { passwordList.length > 0 ?
+                                <div>
+                                    <Alert color="success">Hier könnt ihr euch die generierten Anmeldecodes herunterladen. Solltet ihr nicht genug erstellt haben, meldet euch bitte bei den Administratoren.<br />
+                                    <b>Anleitung:</b><br />
+                                    <ol>
+                                        <li>Excel öffnen</li>
+                                        <li>Reiter <i>Daten</i> anwählen</li>
+                                        <li><i>Aus Text/CSV</i> auswählen</li>
+                                        <li>Passwortliste auswählen und importieren</li>
+                                        <li><i>Komma</i> als Trennzeichen wählen und Daten <i>Laden</i></li>
+                                    </ol>
+                                    </Alert>
+                                    <Row>
+                                        <Col>
+                                            <CSVLink 
+                                                data={this.getCouncilPasswords(passwordList)}
+                                                filename={"FachschaftsPasswörter.csv"}
+                                                style={{marginRight: 10}}
+                                            >
+                                                <Button>
+                                                    <FaDownload /> Fachschafts Passwörter
+                                                </Button>
+                                            </CSVLink>
+                                            <CSVLink 
+                                                data={this.getOtherPasswords(passwordList)}
+                                                filename={"WeiterePasswörter.csv"}
+                                                style={{marginRight: 10}}
+                                            >
+                                                <Button>
+                                                    <FaDownload /> Weitere Passwörter
+                                                </Button>
+                                            </CSVLink>
+                                        </Col>
+                                    </Row>
+                                </div>
+                                :
+                                <div>
+                                    <Alert color="info">Hier könnt ihr eure Anmeldecodes erstellen. Jede Fachschaft bekommt automatisch 6 Anmeldecodes, welche von 1-6 priorisiert sind.<br/>
+                                    Alumni, Rat und mögliche Helfer melden sich über weitere Codes an. Ihr müsst dafür angeben, wieviele weitere Codes ihr benötigt.<br /><b>Da die Codes nur einmal erstellt werden können, gebt besser ein paar Codes mehr an als nötig.</b></Alert>
+                                    <Row>
+                                        <Col xs={12} md={2}>
+                                            <Input 
+                                                type="number"
+                                                value={this.state.otherKeys}
+                                                onChange={(e) => this.setState({ otherKeys: e.currentTarget.value})}
+                                            />
+                                        </Col>
+                                        <Col>
+                                            <Button onClick={() => this.props.generateAuthenticationKeys(this.state.otherKeys)}></Button>
+                                        </Col>
+                                    </Row>
+                                </div>                            
+                            }
+                        </Delay>
                     </CardBody>
                 </Card>
             </Col>
@@ -154,6 +237,7 @@ class DashboardPage extends React.Component {
 const mapStateToProps = (state) => {
   return {
     conference: state.conference.conference,
+    passwordList: state.conference.passwordList,
   }
 }
 
@@ -161,6 +245,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     updatePhases: (data) => dispatch(ConferenceActions.updatePhases(data)),
     generateAuthenticationKeys: (otherKeysCount) => dispatch(ConferenceActions.generateAuthenticationKeys(otherKeysCount)),
+    getPasswordList: () => dispatch(ConferenceActions.getPasswordList()),
   }
 }
 

--- a/src/pages/administrator/PhasesPage.js
+++ b/src/pages/administrator/PhasesPage.js
@@ -5,11 +5,13 @@ import {
   Card,
   CardHeader,
   CardBody,
+  CardTitle,
   Row,
   Col,
   FormGroup,
   Label,
   Input,
+  Alert,
   Button,
 } from 'reactstrap'
 import PageSpinner from '../../components/PageSpinner';
@@ -30,6 +32,7 @@ class DashboardPage extends React.Component {
             conferenceApplicationPhase: false,
             workshopApplicationPhase: false,
             workshopSuggestionPhase: false,
+            otherKeys: 50,
         }
     }
 
@@ -119,6 +122,28 @@ class DashboardPage extends React.Component {
 
                     </CardBody>
                 </Card>
+                <Card style={{marginTop: 10}}>
+                    <CardHeader>
+                        <CardTitle>
+                            Anmeldecodes
+                        </CardTitle>
+                    </CardHeader>
+                    <CardBody>
+                         <Alert color="info">Hier könnt ihr eure Anmeldecodes erstellen und herunterladen. Zu den Weiteren Codes zählen Alumni, Rat und mögliche Helfer-Anmeldungen.<br/><b>Da die Codes nur einmal erstellt werden können, gebt besser ein paar Codes mehr an als nötig.</b></Alert>
+                        <Row>
+                            <Col xs={12} md={2}>
+                                <Input 
+                                    type="number"
+                                    value={this.state.otherKeys}
+                                    onChange={(e) => this.setState({ otherKeys: e.currentTarget.value})}
+                                />
+                            </Col>
+                            <Col>
+                                <Button onClick={() => this.props.generateAuthenticationKeys(this.state.otherKeys)}>Erstellen</Button>
+                            </Col>
+                        </Row>
+                    </CardBody>
+                </Card>
             </Col>
         </Row>
      </Page>
@@ -134,7 +159,8 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    updatePhases: (data) => dispatch(ConferenceActions.updatePhases(data))
+    updatePhases: (data) => dispatch(ConferenceActions.updatePhases(data)),
+    generateAuthenticationKeys: (otherKeysCount) => dispatch(ConferenceActions.generateAuthenticationKeys(otherKeysCount)),
   }
 }
 

--- a/src/redux/conferenceRedux.js
+++ b/src/redux/conferenceRedux.js
@@ -22,6 +22,8 @@ const { Types, Creators } = createActions({
   uploadApplication: ['application'],
   updatePassword: ['password'],
   generateAuthenticationKeys: ['otherKeysCount'],
+  updatePasswordList: ['passwordList'],
+  getPasswordList: null,
 })
 
 export const ConferenceTypes = Types
@@ -39,6 +41,7 @@ export const INITIAL_STATE = Immutable({
     application: null,
     // password protection
     password: '',
+    passwordList: [],
     isPasswordValid: false,
     priority: 0,
     isOtherKey: false,
@@ -73,6 +76,9 @@ export const updateApplication = (state, { application }) =>
 export const updatePassword = (state, { password }) =>
   state.merge({ password })
 
+export const updatePasswordList = (state, { passwordList }) =>
+  state.merge({ passwordList })
+
 /* ------------- Hookup Reducers To Types ------------- */
 
 export const reducer = createReducer(INITIAL_STATE, {
@@ -85,4 +91,5 @@ export const reducer = createReducer(INITIAL_STATE, {
   [Types.UPDATE_APPLICATION_LIST]: updateApplicationList,
   [Types.UPDATE_APPLICATION]: updateApplication,
   [Types.UPDATE_PASSWORD]: updatePassword,
+  [Types.UPDATE_PASSWORD_LIST]: updatePasswordList,
 })

--- a/src/redux/conferenceRedux.js
+++ b/src/redux/conferenceRedux.js
@@ -21,6 +21,7 @@ const { Types, Creators } = createActions({
   updateApplication: ['application'],
   uploadApplication: ['application'],
   updatePassword: ['password'],
+  generateAuthenticationKeys: ['otherKeysCount'],
 })
 
 export const ConferenceTypes = Types

--- a/src/sagas/conferenceSagas.js
+++ b/src/sagas/conferenceSagas.js
@@ -177,10 +177,20 @@ export function* getUsers() {
 export function* generateAuthenticationKeys(action) {
     try {
         const { otherKeysCount } = action
-        console.log("Starting to fetch", otherKeysCount)
-        const result = yield call(apiFetch, 'ApplicationAuths/generate', 'PUT', {otherKeysCount})
-        console.log("result", result)
+        yield call(apiFetch, 'ApplicationAuths/generate', 'PUT', {otherKeysCount})
+        yield call(getPasswordList)
     } catch(e) {
         console.log('Error generating Authentication Keys', e)
+    }
+}
+
+export function* getPasswordList() {
+    try {
+        const result = yield call(apiFetch, 'ApplicationAuths/forConference')
+        if (result) {
+            yield put(ConferenceActions.updatePasswordList(result))
+        }
+    } catch (e) {
+        console.log('Error getting Passwordlist', e)
     }
 }

--- a/src/sagas/conferenceSagas.js
+++ b/src/sagas/conferenceSagas.js
@@ -173,3 +173,14 @@ export function* getUsers() {
         console.log('GetUser', e)
     }
 }
+
+export function* generateAuthenticationKeys(action) {
+    try {
+        const { otherKeysCount } = action
+        console.log("Starting to fetch", otherKeysCount)
+        const result = yield call(apiFetch, 'ApplicationAuths/generate', 'PUT', {otherKeysCount})
+        console.log("result", result)
+    } catch(e) {
+        console.log('Error generating Authentication Keys', e)
+    }
+}

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -27,6 +27,7 @@ import {
   getApplication,
   uploadApplication,
   checkPassword,
+  generateAuthenticationKeys,
 } from './conferenceSagas'
 import { getCouncil, getCouncilList } from './councilSagas'
 import { 
@@ -63,6 +64,7 @@ export default function * root () {
     takeEvery(ConferenceTypes.GET_APPLICATION, getApplication),
     takeEvery(ConferenceTypes.UPLOAD_APPLICATION, uploadApplication), 
     takeEvery(ConferenceTypes.CHECK_PASSWORD, checkPassword),
+    takeLatest(ConferenceTypes.GENERATE_AUTHENTICATION_KEYS, generateAuthenticationKeys),
     // Council
     takeEvery(CouncilTypes.GET_COUNCIL, getCouncil),
     takeEvery(CouncilTypes.GET_COUNCIL_LIST, getCouncilList),

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -28,6 +28,7 @@ import {
   uploadApplication,
   checkPassword,
   generateAuthenticationKeys,
+  getPasswordList,
 } from './conferenceSagas'
 import { getCouncil, getCouncilList } from './councilSagas'
 import { 
@@ -65,6 +66,7 @@ export default function * root () {
     takeEvery(ConferenceTypes.UPLOAD_APPLICATION, uploadApplication), 
     takeEvery(ConferenceTypes.CHECK_PASSWORD, checkPassword),
     takeLatest(ConferenceTypes.GENERATE_AUTHENTICATION_KEYS, generateAuthenticationKeys),
+    takeLatest(ConferenceTypes.GET_PASSWORD_LIST, getPasswordList),
     // Council
     takeEvery(CouncilTypes.GET_COUNCIL, getCouncil),
     takeEvery(CouncilTypes.GET_COUNCIL_LIST, getCouncilList),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9696,6 +9696,11 @@ react-component-queries@^2.3.0:
   dependencies:
     invariant "^2.2.2"
 
+react-csv@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-1.1.2.tgz#6cb47e625f51878d24bb68a120efb45a30ad243a"
+  integrity sha512-pTOTYntW+gQWzCxyEGfS5ZeOfQw4Mu3B+DJd4jrJKNuAWFQ+EEyF2Earfg0+FVEkPwMr62OLtbYCHmc6vQWj2w==
+
 react-d3-map-core@^0.13.5:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/react-d3-map-core/-/react-d3-map-core-0.13.7.tgz#9ddae8c00076a24b901780d1bf14c6006ba0b909"


### PR DESCRIPTION
fix #72 
Admins can now generate passwords for applications while stating how many `otherKeys` they need:
- [x] Phases tab renamed to settings
- [x] generate application passwords including the otherKeys
- [x] download lists with passwords for councils and other participants