### PR TITLE
fix(redux): clear redux storage on logout

### DIFF
--- a/src/redux/conferenceRedux.js
+++ b/src/redux/conferenceRedux.js
@@ -25,7 +25,8 @@ const { Types, Creators } = createActions({
   updatePasswordList: ['passwordList'],
   getPasswordList: null,
   getBadgeList: null,
-  updateBadgeList: ['badgeList']
+  updateBadgeList: ['badgeList'],
+  resetConferenceState: null,
 })
 
 export const ConferenceTypes = Types
@@ -86,6 +87,8 @@ export const updatePasswordList = (state, { passwordList }) =>
 export const updateBadgeList = (state, { badgeList }) =>
   state.merge({ badgeList })
 
+export const resetConferenceState = () => INITIAL_STATE
+
 /* ------------- Hookup Reducers To Types ------------- */
 
 export const reducer = createReducer(INITIAL_STATE, {
@@ -100,4 +103,5 @@ export const reducer = createReducer(INITIAL_STATE, {
   [Types.UPDATE_PASSWORD]: updatePassword,
   [Types.UPDATE_PASSWORD_LIST]: updatePasswordList,
   [Types.UPDATE_BADGE_LIST]: updateBadgeList,
+  [Types.RESET_CONFERENCE_STATE]: resetConferenceState,
 })

--- a/src/redux/councilRedux.js
+++ b/src/redux/councilRedux.js
@@ -12,6 +12,7 @@ const { Types, Creators } = createActions({
   getCouncilList: null,
   applyForCouncil: ['data'],
   updateCouncilFetching: ['fetching'],
+  resetCouncilState: null,
 })
 
 export const CouncilTypes = Types
@@ -45,6 +46,8 @@ export const updateCouncilError = (state, { error }) =>
 export const updateCouncilFetching = (state, { fetching }) =>
   state.merge({ fetching })
 
+  export const resetCouncilState = () => INITIAL_STATE
+
 /* ------------- Hookup Reducers To Types ------------- */
 
 export const reducer = createReducer(INITIAL_STATE, {
@@ -53,4 +56,5 @@ export const reducer = createReducer(INITIAL_STATE, {
   [Types.UPDATE_COUNCIL]: updateCouncil,
   [Types.UPDATE_COUNCIL_ERROR]: updateCouncilError,
   [Types.UPDATE_COUNCIL_FETCHING]: updateCouncilFetching,
+  [Types.RESET_COUNCIL_STATE]: resetCouncilState,
 })

--- a/src/redux/workshopRedux.js
+++ b/src/redux/workshopRedux.js
@@ -20,6 +20,7 @@ const { Types, Creators } = createActions({
     deleteWorkshop: ['id'],
     uploadWorkshopApplication: ['application'],
     getWorkshopApplication: ['uid'],
+    resetWorkshopState: null,
 })
 
 export const WorkshopTypes = Types
@@ -72,6 +73,8 @@ export const updateWorkshopApplication = (state, { workshopApplication }) => {
   return state.merge({ workshopApplication })  
 }
 
+export const resetWorkshopState = () => INITIAL_STATE
+
 /* ------------- Hookup Reducers To Types ------------- */
 
 export const reducer = createReducer(INITIAL_STATE, {
@@ -83,4 +86,5 @@ export const reducer = createReducer(INITIAL_STATE, {
   [Types.UPDATE_ERROR]: updateError,
   [Types.UPDATE_FETCHING]: updateFetching,
   [Types.UPDATE_SUCCESS]: updateSuccess,
+  [Types.RESET_WORKSHOP_STATE]: resetWorkshopState,
 })

--- a/src/sagas/authSagas.js
+++ b/src/sagas/authSagas.js
@@ -1,6 +1,8 @@
 import { call, put, select } from 'redux-saga/effects'
 import AuthActions from '../redux/authRedux'
 import ConferenceActions from '../redux/conferenceRedux'
+import CouncilActions from '../redux/councilRedux'
+import WorkshopActions from '../redux/workshopRedux'
 import { apiFetch } from '../utils/functions'
 import { getWorkshopApplication } from './workshopSagas'
 
@@ -166,6 +168,9 @@ export function* logout(action) {
   try {
     localStorage.clear()
     sessionStorage.clear()
+    yield put(ConferenceActions.resetConferenceState())
+    yield put(CouncilActions.resetCouncilState())
+    yield put(WorkshopActions.resetWorkshopState())
     yield put(AuthActions.resetAuthState())
   } catch (e) {
     console.log('Error at logging out', e)


### PR DESCRIPTION
Prevents a bug where several people from a student council of Jena were allowed to apply to a conference with the same password, as this password remained stored despite logging out.
closes #90

Should be on the Master branch until tomorrow, because the application phase for the BuFaK Neuland is starting then.