### PR TITLE
login button type submit, format in dataprotection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+package-lock.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 .env.development.local
 .env.test.local
 .env.production.local
-package-lock.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -339,7 +339,8 @@ class AuthForm extends React.Component {
           size="lg"
           className="bg-gradient-theme-left border-0"
           block
-          onClick={this.handleSubmit}>
+          onClick={this.handleSubmit}
+          type="submit">
           {this.renderButtonText()}
         </Button>
 

--- a/src/pages/DataProtectionPage.js
+++ b/src/pages/DataProtectionPage.js
@@ -85,9 +85,9 @@ class DataProtectionPage extends React.Component {
                 Dies ist für die während des Registrierungsvorgangs erhobenen Daten der Fall, wenn die bereitgestellte Anmeldung zu einer BuFaK oder die Registrierung auf unserer Internetseite aufgehoben oder abgeändert wird.
             </p>
             <h6>5. Widerspruchs- und Beseitigungsmöglichkeit</h6>
-            <p>Als Nutzer haben sie jederzeit die Möglichkeit, die Registrierung aufzulösen. Senden Sie dafür eine formlose E-Mail an 
+            <p>Als Nutzer haben sie jederzeit die Möglichkeit, die Registrierung aufzulösen. Senden Sie dafür eine formlose E-Mail an&nbsp;
                     <a href='m&#97;il&#116;o&#58;&#105;n%66o&#64;b%&#55;5%66a&#107;&#46;un&#105;-pad%65&#114;bo%72&#110;&#46;d%6&#53;' target="_blank" rel="noopener noreferrer">info&#64;bufak&#46;&#117;n&#105;-p&#97;der&#98;or&#110;&#46;d&#101;</a>.
-                Die über Sie gespeicherten Daten können Sie jederzeit abändern lassen unter <i>> Profil Aktualisieren > Jetzt Aktualisieren</i>.
+                Die über Sie gespeicherten Daten können Sie jederzeit abändern lassen unter <i> &gt; Profil Aktualisieren &gt; Jetzt Aktualisieren</i>.
                 Sind die Daten zur Erfüllung eines Vertrages oder zur Durchführung vorvertraglicher Maßnahmen erforderlich, ist eine vorzeitige Löschung der Daten nur möglich, soweit nicht vertragliche oder gesetzliche Verpflichtungen einer Löschung entgegenstehen.
             </p>
             <h4>Anmeldung zu einer BuFaK</h4><br />
@@ -119,7 +119,7 @@ class DataProtectionPage extends React.Component {
                 Für die Daten (3) - (8) ist dies unmittelbar nach der Ausrichtung der BuFaK der Fall.
             </p>
             <h6>5. Widerspruchs- und Beseitigungsmöglichkeit</h6>
-            <p>Als Nutzer haben sie jederzeit die Möglichkeit, die Anmeldung aufzulösen oder abzuändern. Senden Sie dafür eine formlose E-Mail an 
+            <p>Als Nutzer haben sie jederzeit die Möglichkeit, die Anmeldung aufzulösen oder abzuändern. Senden Sie dafür eine formlose E-Mail an&nbsp; 
                 <a href='m&#97;il&#116;o&#58;&#105;n%66o&#64;b%&#55;5%66a&#107;&#46;un&#105;-pad%65&#114;bo%72&#110;&#46;d%6&#53;' target="_blank" rel="noopener noreferrer">info&#64;bufak&#46;&#117;n&#105;-p&#97;der&#98;or&#110;&#46;d&#101;</a>.
                 Sind die Daten zur Erfüllung eines Vertrages oder zur Durchführung vorvertraglicher Maßnahmen erforderlich, ist eine vorzeitige Löschung der Daten nur möglich, soweit nicht vertragliche oder gesetzliche Verpflichtungen einer Löschung entgegenstehen.
             </p>


### PR DESCRIPTION
added package-lock.json to .gitignore
changed login and signup button types to submit so users can submit the form with enter key
added formatting in data protection, spaces in front of email-addresses, changed "&gt;" to resolve compilation error in dev environment 